### PR TITLE
Rebuild adjacent chunks when editing blocks

### DIFF
--- a/code/Game.cs
+++ b/code/Game.cs
@@ -107,6 +107,14 @@ namespace Sandblox
 
 							build = true;
 						}
+						
+						for ( int i = 0; i < 6; i++ )
+						{
+							var adjacentPos = Map.GetAdjacentPos( x3, y3, z3, i );
+							var adjadentChunkIndex = (adjacentPos.x / Chunk.ChunkSize) + (adjacentPos.y / Chunk.ChunkSize) * numChunksX + (adjacentPos.z / Chunk.ChunkSize) * numChunksX * numChunksY;
+							
+							chunkids.Add( adjadentChunkIndex );
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This rebuilds adjacent chunks when editing blocks, fixing an issue where a block would be missing a face when a block is adjacent to another chunk